### PR TITLE
Fix error check before curl_exec in cURLdownload

### DIFF
--- a/lib/theidentityhub/theidentityhub.php
+++ b/lib/theidentityhub/theidentityhub.php
@@ -488,7 +488,7 @@
          		if( !curl_setopt ($ch, CURLOPT_POST, 1))                { $this->errors[] = "FAIL: curl_setopt(CURLOPT_POST)"; }
 			}
             
-            if (count($this->errors == 0)) { $result = curl_exec($ch); }
+            if (count($this->errors) === 0) { $result = curl_exec($ch); }
 
             curl_close($ch);
 						


### PR DESCRIPTION
In cURLdownload there's a check to see if there were any errors initializing curl before calling curl_exec, but the check isn't correct.

Now it's: `if (count($this->errors == 0))`

But it should of course be: `if (count($this->errors) === 0)`

(I also made it a strict comparison.)